### PR TITLE
バリデーション追加

### DIFF
--- a/src/main/java/payroll/controller/EmployeeController.java
+++ b/src/main/java/payroll/controller/EmployeeController.java
@@ -98,12 +98,21 @@ public class EmployeeController {
 
     /**
      * 従業員情報を更新
-     * @param newEmployee Employeeオブジェクト
+     * @param employeeForm 従業員フォームオブジェクト
      * @param id 従業員id
      * @return ResponseEntity
      */
     @PutMapping("/employees/{id:[0-9]+}")
-    public ResponseEntity<?> replaceEmployee(@RequestBody Employee newEmployee, @PathVariable Long id) {
+    public ResponseEntity<?> replaceEmployee(
+        @RequestBody @Validated EmployeeForm employeeForm,
+        @PathVariable Long id
+    ) {
+
+        Employee newEmployee = new Employee(
+            employeeForm.getFirstName(),
+            employeeForm.getLastName(),
+            employeeForm.getRole()
+        );
 
         Employee updatedEmployee = repository.findById(id)
             .map(employee -> {

--- a/src/main/java/payroll/controller/OrderController.java
+++ b/src/main/java/payroll/controller/OrderController.java
@@ -90,9 +90,11 @@ public class OrderController {
     @PostMapping("/orders")
     public ResponseEntity<EntityModel<Order>> newOrder(@RequestBody @Validated OrderForm orderForm) {
 
-        Order order = new Order(orderForm.getDescription(), orderForm.getStatus());
+        Order order = new Order(
+            orderForm.getDescription(),
+            Status.IN_PROGRESS
+        );
 
-        order.setStatus(Status.IN_PROGRESS);
         Order newOrder = orderRepository.save(order);
 
         return ResponseEntity

--- a/src/main/java/payroll/controller/OrderController.java
+++ b/src/main/java/payroll/controller/OrderController.java
@@ -8,9 +8,11 @@ import org.springframework.hateoas.mediatype.problem.Problem;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.*;
 import payroll.assembler.OrderModelAssembler;
 import payroll.exception.OrderNotFoundException;
+import payroll.form.OrderForm;
 import payroll.repositry.OrderRepository;
 import payroll.entity.Order;
 import payroll.enums.Status;
@@ -82,12 +84,15 @@ public class OrderController {
 
     /**
      * 注文情報を登録
-     * @param order 注文情報
+     * @param orderForm 注文フォームオブジェクト
      * @return ResponseEntity<EntityModel<Order>>
      */
     @PostMapping("/orders")
-    public ResponseEntity<EntityModel<Order>> newOrder(@RequestBody Order order) {
+    public ResponseEntity<EntityModel<Order>> newOrder(@RequestBody @Validated OrderForm orderForm) {
 
+        Order order = new Order();
+
+        order.setDescription(orderForm.getDescription());
         order.setStatus(Status.IN_PROGRESS);
         Order newOrder = orderRepository.save(order);
 

--- a/src/main/java/payroll/controller/OrderController.java
+++ b/src/main/java/payroll/controller/OrderController.java
@@ -90,9 +90,8 @@ public class OrderController {
     @PostMapping("/orders")
     public ResponseEntity<EntityModel<Order>> newOrder(@RequestBody @Validated OrderForm orderForm) {
 
-        Order order = new Order();
+        Order order = new Order(orderForm.getDescription(), orderForm.getStatus());
 
-        order.setDescription(orderForm.getDescription());
         order.setStatus(Status.IN_PROGRESS);
         Order newOrder = orderRepository.save(order);
 

--- a/src/main/java/payroll/form/OrderForm.java
+++ b/src/main/java/payroll/form/OrderForm.java
@@ -1,0 +1,18 @@
+package payroll.form;
+
+import lombok.Data;
+import org.hibernate.validator.constraints.Length;
+
+import javax.validation.constraints.NotBlank;
+
+/**
+ * 注文フォーム
+ */
+@Data
+public class OrderForm {
+
+    /** 注文内容 */
+    @NotBlank
+    @Length(min = 11, max = 50)
+    private String description;
+    }

--- a/src/main/java/payroll/form/OrderForm.java
+++ b/src/main/java/payroll/form/OrderForm.java
@@ -16,7 +16,4 @@ public class OrderForm {
     @NotBlank
     @Length(min = 11, max = 50)
     private String description;
-
-    /** ステータス */
-    private Status status;
 }

--- a/src/main/java/payroll/form/OrderForm.java
+++ b/src/main/java/payroll/form/OrderForm.java
@@ -2,6 +2,7 @@ package payroll.form;
 
 import lombok.Data;
 import org.hibernate.validator.constraints.Length;
+import payroll.enums.Status;
 
 import javax.validation.constraints.NotBlank;
 
@@ -15,4 +16,7 @@ public class OrderForm {
     @NotBlank
     @Length(min = 11, max = 50)
     private String description;
-    }
+
+    /** ステータス */
+    private Status status;
+}


### PR DESCRIPTION
## 修正内容
・バリデーション用のフォームクラスを作成
・コントローラにバリデーション用のアノテーションを追加

## 動作確認
ルールに該当しないリクエストが来た場合は400エラーが返るようになっていることを確認。

以下のルールでバリデート

- employee
    - put … postと同じ（ので同じフォームクラス使う）

- order
    - post
    ・description
    未入力時エラー
    10文字未満、51文字以上はエラー
    status は 定義不要
